### PR TITLE
Allow custom logout URL

### DIFF
--- a/BasicAuthenticator.php
+++ b/BasicAuthenticator.php
@@ -77,7 +77,7 @@ class BasicAuthenticator implements BasicAuthenticatorInterface
   protected $logoutOptions = array(
     'return' => null,
     'logoutFromIdP' => true,
-    'IdPLogoutURL' => self::UMN_IDP_ENTITY_ID
+    'IdPLogoutURL' => self::UMN_IDP_LOGOUT_URL
   );
   /**
    * Custom IdP entity ID used when checking session status
@@ -239,7 +239,7 @@ class BasicAuthenticator implements BasicAuthenticatorInterface
 
     $params = array();
     if ($options['logoutFromIdP']) {
-      $logoutReturn = self::UMN_IDP_LOGOUT_URL;
+      $logoutReturn = $options['IdPLogoutURL'];
 
       // Append the urlencoded final return.
       // Examples in docs show a single-encoded final return, but to spec it should be encoded

--- a/Test/BasicAuthenticatorTest.php
+++ b/Test/BasicAuthenticatorTest.php
@@ -83,7 +83,7 @@ class BasicAuthenticatorTest extends \PHPUnit_Framework_TestCase
     $expected_logout_options = array(
       'return' => 'http://www.example.com',
       'logoutFromIdP' => false,
-      'IdPLogoutURL' => BasicAuthenticator::UMN_IDP_ENTITY_ID,
+      'IdPLogoutURL' => BasicAuthenticator::UMN_IDP_LOGOUT_URL,
       'otherOption' => true
     );
     $shib = new BasicAuthenticator(null, $input_logout_options);


### PR DESCRIPTION
Allow the logoutOptions array to control the logout URL.  This array can then be set via the constructor, allowing for both login and logout with non-UMN IdPs.
